### PR TITLE
Bug fix: copy input vector when calling in-place proximal operator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProximalMethods"
 uuid = "4206358c-74de-4262-b9b2-8440947a766f"
 authors = ["Quint Wiersma <qnt.wrsm@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/proximal.jl
+++ b/src/proximal.jl
@@ -152,7 +152,7 @@ function shrinkage(
     fac::Factorization, 
     b::AbstractVector
 )
-    y= similar(x)
+    y= copy(x)
     shrinkage!(y, λ, fac, b)
 
     return y
@@ -207,7 +207,7 @@ function shrinkage(
     A::AbstractMatrix, 
     b::AbstractVector
 )
-    y= similar(x)
+    y= copy(x)
     shrinkage!(y, λ, A, b)
 
     return y


### PR DESCRIPTION
Copy input vector into a new vector before calling in-place proximal operator version internally.

Resolve #12 